### PR TITLE
Support Qt 6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,18 +26,29 @@ jobs:
           - os: macos-latest
             os-name: mac
             qt-version: '5.15.2'
+
+          - os: ubuntu-latest
+            os-name: linux
+            qt-version: '6.2.*'
+            modules: 'qtmultimedia'
+
     defaults:
       run:
         shell: bash
 
     steps:
       - name: Install Qt
-        uses: jurplel/install-qt-action@v2
+        uses: jurplel/install-qt-action@v3
         with:
           version: ${{ matrix.qt-version }}
           host: ${{ matrix.os-name }}
           arch: ${{ startsWith(matrix.os-name, 'win') && format('win32_mingw{0}', matrix.mingw-short-version) || ''}}
-          tools: ${{ startsWith(matrix.os-name, 'win') && format('tools_mingw,7.3.0,qt.tools.win32_mingw{0}0', matrix.mingw-short-version) || '' }}
+          tools: ${{ startsWith(matrix.os-name, 'win') && format('tools_mingw,qt.tools.win32_mingw{0}0', matrix.mingw-short-version) || '' }}
+          modules: ${{ matrix.modules }}
+
+      - name: Install dependencies 
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get install -y gstreamer1.0-plugins-bad gstreamer1.0-libav gstreamer1.0-plugins-base
 
       - name: Update PATH
         if: ${{ startsWith(matrix.os-name, 'win') }}

--- a/connectionManager.cpp
+++ b/connectionManager.cpp
@@ -63,10 +63,17 @@ void ConnectionManager::reconnectToHost()
 	QEventLoop loop;
 	QTimer::singleShot(timeout, &loop, &QEventLoop::quit);
 	connect(mSocket, &QTcpSocket::connected, &loop, &QEventLoop::quit);
+#ifdef TRIK_USE_QT6
+	connect(mSocket
+			, static_cast<void(QTcpSocket::*)(QAbstractSocket::SocketError)>(&QTcpSocket::errorOccurred)
+			, &loop
+			, [&loop](QAbstractSocket::SocketError) { loop.quit(); });
+#else
 	connect(mSocket
 			, static_cast<void(QTcpSocket::*)(QAbstractSocket::SocketError)>(&QTcpSocket::error)
 			, &loop
 			, [&loop](QAbstractSocket::SocketError) { loop.quit(); });
+#endif
 	mSocket->setProxy(QNetworkProxy::NoProxy);
 	const auto &gamepadIp = mSettings->value("gamepadIp").toString();
 	auto gamepadPort = static_cast<quint16>(mSettings->value("gamepadPort").toUInt());

--- a/gamepadForm.cpp
+++ b/gamepadForm.cpp
@@ -23,8 +23,12 @@
 #include <QtGui/QKeyEvent>
 
 #include <QtNetwork/QNetworkRequest>
-#include <QtMultimedia/QMediaContent>
 #include <QtGui/QFontDatabase>
+
+#ifdef TRIK_USE_QT6
+#else
+	#include <QtMultimedia/QMediaContent>
+#endif
 
 GamepadForm::GamepadForm()
 	: mUi(new Ui::GamepadForm())
@@ -95,10 +99,18 @@ void GamepadForm::setVideoController()
 	mUi->verticalLayout->addWidget(videoWidget);
 	mUi->verticalLayout->setAlignment(videoWidget, Qt::AlignCenter);
 
+#ifdef TRIK_USE_QT6
+	player = new QMediaPlayer(videoWidget);
+#else
 	player = new QMediaPlayer(videoWidget, QMediaPlayer::StreamPlayback);
+#endif
 
 	connect(player, &QMediaPlayer::mediaStatusChanged, this, &GamepadForm::handleMediaStatusChanged);
+#ifdef TRIK_USE_QT6
+	connect(player, &QMediaPlayer::errorOccurred, this, &GamepadForm::handleMediaPlayerError);
+#else
 	connect(player, QOverload<QMediaPlayer::Error>::of(&QMediaPlayer::error), this, &GamepadForm::handleMediaPlayerError);
+#endif
 
 	player->setVideoOutput(videoWidget);
 
@@ -173,7 +185,11 @@ void GamepadForm::restartVideoStream()
 		// QNetworkRequest nr = QNetworkRequest(url);
 		// nr.setPriority(QNetworkRequest::LowPriority);
 		// nr.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::AlwaysCache);
+#ifdef TRIK_USE_QT6
+		player->setSource(QUrl(url));
+#else
 		player->setMedia(QUrl(url));
+#endif
 	}
 }
 
@@ -405,10 +421,16 @@ void GamepadForm::setLabels()
 
 void GamepadForm::setImageControl()
 {
+#ifdef TRIK_USE_QT6
+	sink = videoWidget->videoSink();
+	connect(sink, &QVideoSink::videoFrameChanged, this, &GamepadForm::saveImageToClipboard, Qt::QueuedConnection);
+	player->setVideoSink(sink);
+#else
 	probe = new QVideoProbe(this);
 	connect(probe, &QVideoProbe::videoFrameProbed, this, &GamepadForm::saveImageToClipboard, Qt::QueuedConnection);
-	isFrameNecessary = false;
 	probe->setSource(player);
+#endif
+	isFrameNecessary = false;
 	clipboard = QApplication::clipboard();
 }
 
@@ -468,22 +490,34 @@ void GamepadForm::saveImageToClipboard(QVideoFrame buffer)
 	if (isFrameNecessary) {
 		isFrameNecessary = false;
 		QVideoFrame frame(buffer);
+#ifdef TRIK_USE_QT6
+		frame.map(QVideoFrame::ReadOnly);
+		QImage::Format imageFormat = QVideoFrameFormat::imageFormatFromPixelFormat(frame.pixelFormat());
+#else
 		frame.map(QAbstractVideoBuffer::ReadOnly);
-
 		QImage::Format imageFormat = QVideoFrame::imageFormatFromPixelFormat(frame.pixelFormat());
+#endif
 		QImage img;
 		// check whether videoframe can be transformed to qimage by qt
 		if (imageFormat != QImage::Format_Invalid) {
+#ifdef TRIK_USE_QT6
+			img = frame.toImage();
+#else
 			img = QImage(frame.bits(),
 						 frame.width(),
 						 frame.height(),
 						 // frame.bytesPerLine(),
 						 imageFormat);
+#endif
 		} else {
 			int width = frame.width();
 			int height = frame.height();
 			int size = height * width;
+#ifdef TRIK_USE_QT6
+			const uchar *data = frame.bits(0);
+#else
 			const uchar *data = frame.bits();
+#endif
 
 			img = QImage(width, height, QImage::Format_RGB32);
 			/// converting from yuv420 to rgb32

--- a/gamepadForm.h
+++ b/gamepadForm.h
@@ -20,6 +20,7 @@
 
 #include <QMediaPlayer>
 #include <QVideoWidget>
+#include <QActionGroup>
 
 #include <QWidget>
 #include <QMenuBar>
@@ -30,7 +31,13 @@
 #include <QMovie>
 #include <QThread>
 
-#include <QVideoProbe>
+#ifdef TRIK_USE_QT6
+	#include <QVideoSink>
+#else
+	#include <QVideoProbe>
+#endif
+
+#include <QVideoFrame>
 #include <QClipboard>
 
 #include "connectForm.h"
@@ -198,7 +205,13 @@ private:
 	QMovie movie;
 
 	QClipboard *clipboard { nullptr }; //Doesn't have ownership
+
+#ifdef TRIK_USE_QT6
+	QVideoSink *sink { nullptr }; // TODO [Doesn't have | Has] ownership
+#else
 	QVideoProbe *probe { nullptr }; // TODO [Doesn't have | Has] ownership
+#endif
+
 	bool isFrameNecessary {};
 	QSettings mSettings;
 };

--- a/trikDesktopGamepad.pro
+++ b/trikDesktopGamepad.pro
@@ -24,7 +24,7 @@ QMAKE_CXXFLAGS += -Wno-error=deprecated-declarations
 # Suppressing warnings in Qt system headers files
 QMAKE_CXXFLAGS += -isystem "$$[QT_INSTALL_HEADERS]"
 # QMAKE_CXXFLAGS += -isystem "$(QTDIR)/include/QtMultimediaWidgets"
-
+!lessThan(QT_MAJOR_VERSION, 6):DEFINES += TRIK_USE_QT6
 TARGET = gamepad
 TEMPLATE = app
 


### PR DESCRIPTION
* Port the project to Qt 6 without losing of compatibility on Qt 5 what is reached by adding preprocessor directives which use new macro TRIK_USE_QT6
* Add CI build on Qt 6 for Ubuntu
* Update GitHub action step "Install Qt" by changing the install-qt-action version to the newer one (v3 instead of v2) and adding "modules" parameter which is needed by Qt 6 build